### PR TITLE
Add: libpq-dev and node.js v16.x

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,9 +4,10 @@ ENV PYTHON_VERSION 3.8.12
 ENV DEBIAN_FRONTEND=noninteractive
 #Set of all dependencies needed for pyenv to work on Ubuntu
 RUN apt-get update \ 
-    && apt-get install -y --no-install-recommends make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget ca-certificates curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev mecab-ipadic-utf8 git postgresql-client telnet
+    && apt-get install -y --no-install-recommends make build-essential libssl-dev libpq-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget ca-certificates curl llvm libncurses5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev mecab-ipadic-utf8 git postgresql-client telnet
 
 RUN curl https://cli-assets.heroku.com/install.sh | sh
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && apt-get install -y nodejs
 
 ARG USERNAME=codeany
 RUN useradd -ms /bin/bash $USERNAME


### PR DESCRIPTION
Adding node version 16 to Dockerfile, LTS version 18 causes SSL issue. Codeanywhere seem to use version 16 in their template anyway, so that must be the reason.

Added `libpq-dev` to Dockerfile to allow both psycopg2 and psycopg2-binary to work.

Tested on DRF app, a unifed moments app, Boutique Ado etc...

 