### PR TITLE
Add http.server wrapper

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -41,6 +41,10 @@ RUN echo 'alias heroku_config=". $HOME/.theia/heroku_config.sh"' >> ~/.bashrc
 COPY ./build-assets/make_url.py /home/$USERNAME/.theia/make_url.py
 RUN echo 'alias make_url="python3 $HOME/.theia/make_url.py "' >> ~/.bashrc
 
+COPY ./build-assets/http_server.py /home/$USERNAME/.theia/http_server.py
+RUN echo 'alias http_server="python3 $HOME/.theia/http_server.py "' >> ~/.bashrc
+
+
 USER root
 RUN chown -R $USERNAME:$USERNAME /home/$USERNAME/.theia
 

--- a/.devcontainer/build-assets/http_server.py
+++ b/.devcontainer/build-assets/http_server.py
@@ -1,0 +1,28 @@
+# Simple wrapper for http.server
+# to switch off caching for users
+#
+# Matt Rudge
+# 20th April, 2023
+
+import http.server
+
+
+class NoCacheHTTPHandler(http.server.SimpleHTTPRequestHandler):
+    def end_headers(self):
+        """
+        Overrides default end_headers method
+        """
+        self.send_cache_headers()
+        http.server.SimpleHTTPRequestHandler.end_headers(self)
+
+    def send_cache_headers(self):
+        """
+        New method to send cache control headers
+        """
+        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.send_header("Pragma", "no-cache")
+        self.send_header("Expires", "0")
+
+
+if __name__ == '__main__':
+    http.server.test(HandlerClass=NoCacheHTTPHandler)


### PR DESCRIPTION
This is a small Python wrapper around the `http.server` module. It sends non-caching headers, which should remove 304 status codes and mean that students don't need to hard refresh as much.

Changed files are:

http_server.py - the new wrapper
Dockerfile - added an alias so that the student just needs to type `http_server` to get it running