### PR TITLE
Fixes 'invalid host header' when using a proxy with react/drf

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -49,3 +49,6 @@ USER root
 RUN chown -R $USERNAME:$USERNAME /home/$USERNAME/.theia
 
 CMD ["tail", "-f", "/dev/null"]
+
+# Allows proxy to work for react/drf on cloud ide's
+ENV DANGEROUSLY_DISABLE_HOST_CHECK=true


### PR DESCRIPTION
Despite the scary name, this ENV var is required to allow react to use a proxy on cloud ide's. It was previously in the old gitpod dockerfile, and needs to be added to the new ci-full-template for when students will combine react/drf. ENV var does not affect any other known course content.